### PR TITLE
nginx logging enahancements

### DIFF
--- a/roles/base/tasks/install.yml
+++ b/roles/base/tasks/install.yml
@@ -47,5 +47,7 @@
       debian-archive-keyring,
       fail2ban,
       locate,
-      inotify-tools
+      inotify-tools,
+      jq
     ]
+  tags: ['base-packages']

--- a/roles/nginx-reverse-proxy/tasks/configure.yml
+++ b/roles/nginx-reverse-proxy/tasks/configure.yml
@@ -4,15 +4,7 @@
     dest: /etc/nginx/nginx.conf
     owner: www-data
     group: www-data
-  tags: ['nginx', 'nginx-config']
-
-- name: add nginx ssl configuration
-  template:
-    src: nginx.conf.j2
-    dest: /etc/nginx/nginx.conf
-    owner: www-data
-    group: www-data
-  tags: ['nginx', 'nginx-config']
+  tags: ['nginx', 'nginx-config', 'nginx-base-config']
 
 - name: add nginx ssl configuration
   template:
@@ -29,4 +21,4 @@
     enabled: yes
     state: restarted
   ignore_errors: true
-  tags: ['nginx', 'nginx-config']
+  tags: ['nginx', 'nginx-config', 'nginx-base-config']

--- a/roles/nginx-reverse-proxy/templates/nginx.conf.j2
+++ b/roles/nginx-reverse-proxy/templates/nginx.conf.j2
@@ -17,8 +17,8 @@ http {
   default_type  application/octet-stream;
   access_log    /var/log/nginx/access.log;
 
-  # from https://www.velebit.ai/blog/nginx-json-logging/
-  log_format custom escape=json '{"source": "nginx", "time": $msec, "resp_body_size": $body_bytes_sent, "host": "$http_host", "address": "$remote_addr", "request_length": $request_length, "method": "$request_method", "uri": "$request_uri", "status": $status,  "user_agent": "$http_user_agent", "resp_time": $request_time, "upstream_addr": "$upstream_addr"}';
+  # modified version, original: https://www.velebit.ai/blog/nginx-json-logging/
+  log_format custom escape=json '{"source": "nginx", "time": "$time_iso8601", "resp_body_size": $body_bytes_sent, "host": "$http_host", "address": "$remote_addr", "request_length": $request_length, "method": "$request_method", "uri": "$request_uri", "status": $status,  "user_agent": "$http_user_agent", "referrer" : "$http_referer", "resp_time": "$request_time", "upstream_addr": "$upstream_addr"}';
 
   sendfile      on;
   tcp_nopush    on;


### PR DESCRIPTION
1. Request time is quoted to make parsing with `jq` more resilient.
2. The http_referrer was missing from the log format.
3. Added the 'nginx-base-config' tag to support slicing, i.e, only a partial application of the playbook.
4. `jq` is nice to have on the host.