### PR TITLE
Nginx Rate Limiting Dual Rate Rules

### DIFF
--- a/roles/rails-app/templates/site.j2
+++ b/roles/rails-app/templates/site.j2
@@ -4,9 +4,11 @@ upstream unicorn {
   server 127.0.0.1:3000 fail_timeout=0;
 }
 
-
-limit_req_zone $binary_remote_addr zone=zone_request_limit_second:10m rate=10r/s;
-limit_req_zone $binary_remote_addr zone=zone_request_limit_minute:10m rate=30r/s;
+#########################################################
+## Rate limiting Zone Definition
+#########################################################
+limit_req_zone $binary_remote_addr zone=zone_request_limit_second:10m rate=12r/s;
+limit_req_zone $binary_remote_addr zone=zone_request_limit_minute:10m rate=50r/m;
 
 {% if using_ssl is defined and using_ssl == True %}
 server {


### PR DESCRIPTION
Dual Zone Rate Limiting, see:

> The following will limit users, identified by their network address, both in second and minute intervals - and allow them to temporarily exceed the defined limit for short bursts.

https://serverfault.com/a/976608

Also see: [Queuing With nodelay](https://www.nginx.com/blog/rate-limiting-nginx/)

> With the nodelay parameter... when a request arrives “too soon”, NGINX forwards it immediately as long as there is a slot available for it in the queue

Also see: [Handling Bursts](https://www.nginx.com/blog/rate-limiting-nginx/#bursts)

> The burst parameter defines how many requests a client can make in excess of the rate specified by the zone 